### PR TITLE
Add client build to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,21 @@
-FROM python:3-alpine3.8
+FROM python:3-alpine3.15
 
 ADD app /app/app
 ADD run.py /app
 ADD requirements.txt /app
 
-RUN apk add libmagic && \
+ADD package.json /app
+ADD webpack.config.js /app
+ADD src /app/src
+ADD semantic /app/semantic
+ADD .eslintrc.js /app
+ADD .babelrc /app
+
+
+RUN apk add libmagic npm nodejs && \
   cd /app && \
+  npm install && \
+  npm run webpack && \
   pip3 install -r requirements.txt && \
   mkdir /profiles && \
   sed -i -e s/127.0.0.1/0.0.0.0/g -e s~examples~/profiles~g app/config.py


### PR DESCRIPTION
Latest updates to flamescope resulted in client missing when running it
in docker. Going to http://localhost:5000 ends up with an error as
/app/public is empty.

This commit adds client build steps into the Dockerfile.

Signed-off-by: Marek Kroemeke <kroemeke@gmail.com>